### PR TITLE
add unit to disk parameter of install command

### DIFF
--- a/install.go
+++ b/install.go
@@ -7,7 +7,7 @@ import (
 
 type InstallCommand struct {
 	Cpus    int    `short:"c" long:"cpus" description:"number of CPUs to allocate" default:"1"`
-	Disk    int    `short:"d" long:"disk" description:"size of disk to create" default:"30"`
+	Disk    int    `short:"d" long:"disk" description:"size of disk in GiB to create" default:"30"`
 	Memory  int    `short:"m" long:"memory" description:"amount of memory to allocate" default:"1"`
 	SSHKey  string `short:"s" long:"ssh-key" description:"path to public ssh key" default:"$HOME/.ssh/id_rsa.pub"`
 	Version string `short:"v" long:"os-version" description:"version of DhyveOS to install"`


### PR DESCRIPTION
Docker Machine forces you to take MegaBytes. Perhaps this makes it more clear.
