### PR TITLE
Add launchctl start to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,12 @@ launchctl load ~/Library/LaunchAgents/local.dlite.plist
 
 as your user to start the process. DLite will start automatically upon logging in as well.
 
+Then to start the virtual machine run:
+
+```
+launchctl start local.dlite
+```
+
 ##Usage
 
 Just use Docker. DLite creates a `/var/run/docker.sock` in your host operating system.


### PR DESCRIPTION
After installing and loading the plist the docker virtual machine will not be running. This adds the command for that step (as described in https://blog.andyet.com/2016/01/25/easy-docker-on-osx/)
