### PR TITLE
Use GiB as default disk size unit

### DIFF
--- a/rebuild.go
+++ b/rebuild.go
@@ -5,7 +5,7 @@ import (
 )
 
 type RebuildCommand struct {
-	Disk   int    `short:"d" long:"disk" description:"size of disk to create" default:"30"`
+	Disk   int    `short:"d" long:"disk" description:"size of disk in GiB to create" default:"30"`
 	SSHKey string `short:"s" long:"ssh-key" description:"path to public ssh key" default:"$HOME/.ssh/id_rsa.pub"`
 }
 


### PR DESCRIPTION
This is already done in `install.go` but not here.
