### PR TITLE
Add .travis.yml

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,32 @@
+# Force OS X.
+language: objective-c
+matrix:
+  include:
+    - env: OSX=10.11
+      os: osx
+      osx_image: xcode7.2
+    - env: OSX=10.10
+      os: osx
+      osx_image: xcode7.1
+
+#before_install:
+#  - brew update
+#  - brew outdated go || brew upgrade go
+
+install:
+  - export GOPATH=$TRAVIS_BUILD_DIR
+  - export BUILD_PATH=$TRAVIS_BUILD_DIR/src/github.com/nlf/dlite
+  - mkdir -p $BUILD_PATH
+  - shopt -s extglob dotglob
+  - mv !(src) $BUILD_PATH
+  - shopt -u extglob dotglob
+
+script:
+  - cd $BUILD_PATH
+  - make dlite
+  - ./dlite version
+
+notifications:
+  email:
+    on_success: never
+    on_failure: always

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,7 +9,9 @@ matrix:
       os: osx
       osx_image: xcode7.1
 
-#before_install:
+before_install:
+   - go version
+#  If we wanted to have the newest go version:
 #  - brew update
 #  - brew outdated go || brew upgrade go
 


### PR DESCRIPTION
Add travis CI support. Now we can be sure that `make dlite` works on a system with only go installed (and no dependencies are forgotten).

(@nlf: After merging you have to create an account here: https://travis-ci.org/ and enable tests for this repo. Travis CI is free for OSS)
