### PR TITLE
added info about installing with homebrew

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,15 @@ After compiling dlite simply follow the directions above beginning with:
 sudo dlite install
 ```
 
+### Homebrew
+
+If you have [Homebrew](http://brew.sh/), just run :
+
+```
+brew install dlite
+sudo dlite install
+```
+
 ##Updating DLite
 
 The DLite app itself can be updated by running `dlite stop`, installing the updated binary, and then running `dlite start`.


### PR DESCRIPTION
There's a homebrew formula for dlite since version 1.1.3.

`brew install dlite`

[skip ci]
