### PR TITLE
Ensure the last line in /etc/hosts gets newline on reconstruction

### DIFF
--- a/utils/hosts.go
+++ b/utils/hosts.go
@@ -106,7 +106,7 @@ func AddHost(hostname, ip string) error {
 		return err
 	}
 
-	_, err = file.Write([]byte(strings.Join(lines, "\n")))
+	_, err = file.Write([]byte(strings.Join(lines, "\n")+"\n"))
 	return err
 }
 


### PR DESCRIPTION
Otherwise tools that just append lines will break as they effectively add a comment.
