### PR TITLE
Add README section on routing and DNS

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ There are several ways to install dlite. You may install it with [Homebrew](http
     ```
     go get github.com/nlf/dlite
     ```
-    
+
     After that you need to compile it (run `make dlite` in the `src/github.com/nlf/dlite` dir.)
 
 ### Initialization
@@ -67,6 +67,92 @@ When opening ports in your docker containers, connect to `local.docker` instead 
 Note that the `local.docker` hostname is configurable by passing the `-n` flag to the install command, as in `sudo dlite install -n docker.dev`
 
 If you need to SSH to the VM for whatever reason, `ssh docker@local.docker` should do the trick.
+
+## Seamless routing
+
+By default, Docker creates a virtual interface named `docker0` on the host machine that forwards packets between any other network interface.
+
+However, on OSX, this means you are not able to access the Docker network directly. To be able to do so, you need add a route and allow traffic from any host on the interface that connects to the VM.
+
+Run the following commands on your OSX machine:
+
+```sh
+sudo route -n add 172.17.0.0/16 local.docker
+DOCKER_INTERFACE=$(route get local.docker | grep interface: | cut -f 2 -d: | tr -d ' ')
+DOCKER_INTERFACE_MEMBERSHIP=$(ifconfig ${DOCKER_INTERFACE} | grep member: | cut -f 2 -d: | cut -c 2-4)
+sudo ifconfig "${DOCKER_INTERFACE}" -hostfilter "${DOCKER_INTERFACE_MEMBERSHIP}"
+```
+
+See if it works by pinging the IP of any running container (assuming you have at least one):
+
+```sh
+docker inspect -f '{{.NetworkSettings.IPAddress}}' $(docker ps -q | head -1)
+```
+
+For now, you may include this on a profile script if desired in case you need to repeat the same steps. Unless you reboot your OSX machine, you shouldn't need to run this often.
+
+### Service Discovery via DNS
+
+Now that you've got transparent routing to your Docker containers, it is time to improve their accessibility by using a DNS server.
+
+First, let's start by configuring the default Docker service DNS server to IP where the DNS server will run (`172.17.42.1`). Currently, this requires SSH'ing into the VM and editing `/etc/default/docker`, but this likely to change in the [future](https://github.com/nlf/dlite/issues/90).
+
+Add the DNS server static IP via `--bip` and `--dns`:
+
+```
+DOCKER_ARGS="-H unix:///var/run/docker.sock -H tcp://0.0.0.0:2375 -s btrfs --bip=172.17.42.1/24 --dns=172.17.42.1"
+```
+
+Then edit the rc script `/etc/init.d/S51docker` that starts Docker and run the DNS server on startup:
+
+Add after `[ $? = 0 ] && echo "OK" || echo "FAIL"`:
+
+```sh
+/usr/bin/docker run -d -v /var/run/docker.sock:/var/run/docker.sock --name dnsdock -p 172.17.42.1:53:53/udp tonistiigi/dnsdock
+```
+
+Add before `start-stop-daemon -K -q -p /var/run/docker.pid`:
+
+```sh
+/usr/bin/docker rm --force dnsdock
+```
+
+After all of this is done just restart the Docker service inside the VM to get the DNS server up and running:
+
+```sh
+sudo /etc/init.d/S51docker restart
+```
+
+Lastly, configure OSX so that all `.docker` requests are forwarded to Docker's DNS server. Since routing has already been taken care of, just create a custom resolver under `/etc/resolver/docker` with the following content:
+
+```
+nameserver 172.17.42.1
+```
+
+Then restart OSX's own DNS server:
+
+```
+sudo killall -HUP mDNSResponder
+```
+
+Check if the DNS server is working as expected by querying a running image:
+
+```sh
+dig <image>.docker @172.17.42.1
+```
+
+You should see a Docker network IP resolved correctly:
+
+```
+;; ANSWER SECTION:
+<image>.docker.	0	IN	A	172.17.42.3
+```
+
+#### Troubleshooting DNS
+
+It usually takes some time to adapt to the DNS naming scheme of `dnsdock`, so if you'd like see which DNS names are being registered in real time, just follow the `dnsdock` logs:
+
+`docker logs --follow dnsdock`
 
 ##Troubleshooting
 


### PR DESCRIPTION
This PR is still a bit rough but I wanted to get this out so that we can brainstorm on how to implement this via dlite without needing almost any user interaction. This is a follow-up of https://github.com/nlf/dlite/issues/28.

Caveats:
- Sometimes I need to re-run the commands to add the routes to OSX. I don't know yet when and why this happens.
- I have been unable to get a custom rc script to be called by dhyve that would start the dns server automatically, hence the ugly editing of the Docker service one (and also some weird stuff like the contents of the files not being persisted over a dlite stop && dlite start?).
- For now we cannot pass extra arguments to the Docker service. This is being tracked on https://github.com/nlf/dlite/issues/90.
